### PR TITLE
Calculate averages in card headers based on input$date_range and raw data

### DIFF
--- a/app/logic/aggregation.R
+++ b/app/logic/aggregation.R
@@ -3,11 +3,14 @@ box::use(
   lubridate[floor_date],
   magrittr[`%>%`],
   stats[setNames],
+  tools[toTitleCase],
 )
 
 box::use(
-  app/logic/config_settings[is_config_valid, read_config_yml],
-  app/logic/utils[map_wday],
+  app/logic/utils[
+    week_start_day,
+    week_start_id
+  ],
 )
 
 #' Aggregate usage data based on specified levels and time period
@@ -16,13 +19,9 @@ box::use(
 #' @param date_aggregation Time period for aggregation
 #' @return Aggregated data frame
 aggregate_usage <- function(usage, agg_levels, date_aggregation) {
-  config <- read_config_yml()
-  week_start_day <- ifelse(is.null(config) & is_config_valid(config, "week_start"),
-    "Monday", config$week_start
-  )
   usage$day <- floor_date(usage$start_date, "day")
   usage$week <- floor_date(usage$start_date, "week",
-    week_start = map_wday(week_start_day)
+    week_start = week_start_id
   )
   usage$month <- floor_date(usage$start_date, "month")
 
@@ -110,7 +109,7 @@ process_agg_usage <- function(usage, agg_levels, date_aggregation, apps, users) 
 #' @export
 format_agg_usage <- function(agg_usage, date_aggregation, format_duration) {
   date_col <- switch(date_aggregation,
-    "week" = "Monday Date",
+    "week" = paste(toTitleCase(week_start_day), "Date"),
     "month" = "Month",
     "Date"
   )

--- a/app/logic/charts.R
+++ b/app/logic/charts.R
@@ -3,7 +3,7 @@ box::use(
   echarts4r,
   glue[glue],
   htmlwidgets[JS],
-  lubridate[days, floor_date],
+  lubridate[floor_date],
   magrittr[`%>%`],
   timetk[pad_by_time],
 )
@@ -425,17 +425,23 @@ bar_chart_helper <- function(obj, x, title, date_range,
     echarts4r$e_tooltip()
 }
 
-date_zero_value_filler <- function(agg_usage, date_range, date_aggregation) {
+date_zero_value_filler <- function(
+  agg_usage,
+  date_range,
+  date_aggregation,
+  week_start = utils$week_start_id
+) {
   if (nrow(agg_usage) == 0) {
     return(agg_usage)
   }
 
-  start_date <- switch(date_aggregation,
-    "week" = floor_date(date_range[1], date_aggregation) + days(1),
-    floor_date(date_range[1], date_aggregation)
-  )
+  start_date <- floor_date(date_range[1], date_aggregation, week_start)
 
   end_date <- date_range[2]
+
+  if (start_date == end_date) {
+    return(agg_usage)
+  }
 
   agg_usage %>%
     pad_by_time(

--- a/app/logic/config_settings.R
+++ b/app/logic/config_settings.R
@@ -74,6 +74,10 @@ validate_goal <- function(config, goal_type) {
 }
 
 validate_week_start <- function(config) {
+  if (is.null(config$week_start)) {
+    return(FALSE)
+  }
+
   dows <- c(
     "monday", "tuesday", "wednesday", "thursday", "friday",
     "saturday", "sunday"

--- a/tests/testthat/test-aggregation.R
+++ b/tests/testthat/test-aggregation.R
@@ -3,10 +3,12 @@ box::use(
   lubridate[as_datetime],
   magrittr[`%>%`],
   testthat[describe, expect_equal, it],
+  tools[toTitleCase],
 )
 
 box::use(
   app/logic/aggregation[format_agg_usage, process_agg_usage],
+  app/logic/utils[week_start_day],
 )
 
 describe("process_agg_usage", {
@@ -133,8 +135,9 @@ describe("format_agg_usage", {
     expect_equal(
       colnames(result),
       c(
-        "Application", "Username", "Monday Date", "Session count",
-        "Unique users", "Average session duration"
+        "Application", "Username",
+        paste(toTitleCase(week_start_day), "Date"),
+        "Session count", "Unique users", "Average session duration"
       )
     )
     expect_equal(

--- a/tests/testthat/test-charts.R
+++ b/tests/testthat/test-charts.R
@@ -11,6 +11,19 @@ impl <- attr(charts, "namespace")
 
 context("charts date_zero_value_fillter()")
 
+test_that("returns data as is when start date equals to end date", {
+  test_data <- data.frame(
+    start_date = as.Date(c("2022-10-01")),
+    values = 5
+  )
+
+  date_range <- as.Date(c("2022-10-01", "2022-10-01")) # 1 day
+
+  result <- impl$date_zero_value_filler(test_data, date_range, "day")
+
+  expect_data_frame(result, nrows = 1)
+})
+
 test_that("it fills up by day", {
   test_data <- data.frame(
     start_date = as.Date(c("2022-10-04", "2022-10-11", "2022-10-27")),
@@ -30,11 +43,16 @@ test_that("it fills up by week", {
     values = c(5, 3, 10)
   )
 
-  date_range <- as.Date(c("2022-10-02", "2022-10-29")) # 4 weeks
+  date_range <- as.Date(c("2022-10-02", "2022-10-29")) # 5 calendar weeks
 
-  result <- impl$date_zero_value_filler(test_data, date_range, "week")
+  result <- impl$date_zero_value_filler(
+    test_data,
+    date_range,
+    "week",
+    week_start = 1 # week starts from Monday
+  )
 
-  expect_data_frame(result, nrows = 4)
+  expect_data_frame(result, nrows = 5)
 })
 
 test_that("it fills up by month", {

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -169,4 +169,13 @@ testthat$test_that("validate_week_start validates day names correctly", {
 
   config <- list(week_start = "MONDAY") # Case sensitive
   testthat$expect_false(impl$validate_week_start(config))
+
+  config <- list(week_start = NULL)
+  testthat$expect_false(impl$validate_week_start(config))
+
+  config <- list(week_start = NA)
+  testthat$expect_false(impl$validate_week_start(config))
+
+  config <- list(week_start = "")
+  testthat$expect_false(impl$validate_week_start(config))
 })


### PR DESCRIPTION
## Description
Stats in card headers were calculated based on aggregated data. Instead it should be calculated based on raw data and `input$date_range` values:

1. Renamed "Unique users" to "Average unique users" for more clarity 
2. "Average sessions" and "Average unique users" are calculated as sum(sessions or users)/date range length in selected units (day/week/month)
3. Stats in card headers are calculated based on raw data instead of aggregated data
4. Added `get_date_range_length_in_units()` function to `logic/utils` to calculate date range length in selected units (day/week/month) (with unit tests)
5. Removed `get_grouped_average()` function from `logic/utils` that was used to calculate averages in card headers

Date range input, summary charts and averages in card headers are linked: 

  6. Used `week_start` from `config.yml` to set week start day in `dateRangeInput()`. It requires Sunday to have index `0` and not `7` as in `lubridate` functions, Monday-Saturday indices match for both `dateRangeInput()` and `lubridate`

<div align="center">

Week day | `lubridate` | `shiny::dateRangeInput`
-- | -- | --
Monday | 1 | 1
Tuesday | 2 | 2
Wednesday | 3 | 3
Thursday | 4 | 4
Friday | 5 | 5
Saturday | 6 | 6
**Sunday** | **7** | **0**

</div>

  8. Fixed summary charts to show the exact number of calendar weeks based on `week_start` set in `config.yml`(was working correctly only for Monday) when date aggregation is selected as "weeks", updated corresponding unit tests
  9. Date range length equals to number of grid sections on summary charts (e.g. "Date range" is selected as a two months period and "Date aggregation" is selected as a "month". Chart grid will be divided into two sections (for each month) and date difference used in avg calculations will be also equal to 2)
  10. Fixed a warning in `date_zero_value_filler()` when date range was set to 1 day length
  11. Replaced "Monday Date" column name in summary table for weekly aggregation with `week_start` from `config.yml` (e.g. for `week_start: sunday` column name is "Sunday Date"), updated corresponding unit tests

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
