### PR TITLE
Fit chart title into canvas

### DIFF
--- a/app/logic/charts.R
+++ b/app/logic/charts.R
@@ -329,6 +329,10 @@ chart_title_helper <- function(obj, title, date_range, disclaimer = FALSE) {
   echarts4r$e_title(
     obj,
     text = title,
+    textStyle = list(
+      overflow = "break",
+      width = 600
+    ),
     subtextStyle = list(fontSize = 14)
   )
 }


### PR DESCRIPTION
## Description

Added linebreak for chart titles that are longer than 600px. Did not cover screen size difference cases for mobile devices as an application is used on desktop

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
